### PR TITLE
feat: allow multiple GEMINI_API_KEYS_{%d} environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,18 @@
+# 使用官方 Python 3.11 瘦身镜像作为基础镜像
 FROM python:3.11-slim
 
+# 设置工作目录为 /app
 WORKDIR /app
 
-COPY ./app ./app
-COPY requirements.txt version.txt .
-RUN date +%s > ./app/build_timestamp.txt &&pip install --no-cache-dir -r requirements.txt
+# 复制 requirements.txt 并安装依赖
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
+# 复制当前目录下的所有文件到工作目录
+COPY . .
+
+# 暴露端口 7860
+EXPOSE 7860
+
+# 使用 Uvicorn 启动应用
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "7860"]

--- a/app/utils/api_key.py
+++ b/app/utils/api_key.py
@@ -12,6 +12,14 @@ class APIKeyManager:
     def __init__(self):
         self.api_keys = re.findall(
             r"AIzaSy[a-zA-Z0-9_-]{33}", os.environ.get('GEMINI_API_KEYS', ""))
+        
+        # 加载更多 GEMINI_API_KEYS
+        for i in range(1, 99):
+            if keys := os.environ.get(f"GEMINI_API_KEYS_{i}", ""):
+                self.api_keys += re.findall(r"AIzaSy[a-zA-Z0-9_-]{33}", keys)
+            else:
+                break
+
         self.key_stack = [] # 初始化密钥栈
         self._reset_key_stack() # 初始化时创建随机密钥栈
         # self.api_key_blacklist = set()


### PR DESCRIPTION
Allow multiple GEMINI_API_KEYS_{%d} environment variables
example:
GEMINI_API_KEYS_1
GEMINI_API_KEYS_2
GEMINI_API_KEYS_3
...