### PR TITLE
feat: 解析并保留 Gemini API 响应中的思考内容

### DIFF
--- a/app/utils/response.py
+++ b/app/utils/response.py
@@ -112,9 +112,28 @@ def openAI_from_Gemini(response, stream=True):
             "tool_calls": tool_calls,
         }
     elif response.text:
+        import re
         # 处理普通文本响应
-        content_chunk = {"role": "assistant", "content": response.text}
+        text = response.text
+        # 确保 thoughts 属性存在且不为 None
+        thoughts = response.thoughts if hasattr(response, 'thoughts') and response.thoughts else ""
 
+        # 检查并从 text 中提取 <thought> 标签内容
+        match = re.search(r"<thought>(.*?)</thought>", text, re.DOTALL)
+        if match:
+            extracted_thought = match.group(1).strip()
+            # 如果已经有结构化的 thought，就拼接
+            if thoughts:
+                thoughts = f"{thoughts}\n{extracted_thought}"
+            else:
+                thoughts = extracted_thought
+            # 从主文本中移除 thought 标签
+            text = re.sub(r"<thought>.*?</thought>", "", text, flags=re.DOTALL).strip()
+
+        content_chunk = {"role": "assistant", "content": text}
+        if thoughts:
+            content_chunk["reasoning_content"] = thoughts
+    
     if stream:
         formatted_chunk["choices"][0]["delta"] = content_chunk
         formatted_chunk["object"] = "chat.completion.chunk"

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-version=1.0.3
+version=1.0.4


### PR DESCRIPTION
**问题描述 (Problem)**

当前，当从 Google Gemini API 返回的响应中包含思考过程时（无论是结构化的 thought 部分，还是内嵌在文本中的 <thought> 标签），这部分内容在转换为 OpenAI API 格式时会被丢弃。这导致了模型思考过程信息的丢失，无法在最终输出中查看。

**解决方案 (Solution)**

本次更新修改了 API 响应的转换逻辑，以确保思考内容能够被正确解析并保留：

新增 reasoning_content 字段：在 app/utils/response.py 的 openAI_from_Gemini 函数中增加了新的处理逻辑。
解析 <thought> 标签：新逻辑会使用正则表达式查找并提取响应文本中由 <thought>...</thought> 包裹的内容。
分离内容：提取出的思考内容会被放入新增的 reasoning_content 字段中，同时从原始的 content 字段里移除，确保 content 字段只包含纯净的回复文本。
兼容性：此修改同时兼容结构化思考内容和内嵌标签两种形式，并对流式（streaming）和非流式（non-streaming）响应均有效。

**其他改动 (Other Changes)**

版本号从 1.0.3 更新至 1.0.4。

**效果 (Effect)**

优化后，API 能够像下面这样返回包含了思考过程的响应，符合预期：
```
{
  "id": "...",
  "object": "chat.completion",
  "created": ...,
  "model": "...",
  "choices": [{
    "index": 0,
    "message": {
      "role": "assistant",
      "content": "你好呀！...",
      "reasoning_content": "咦？用户发来的问候有点特别..."
    },
    "finish_reason": "stop"
  }],
  "usage": { ... }
}
```



